### PR TITLE
Fix chip return bug in Games context

### DIFF
--- a/lib/gang/games.ex
+++ b/lib/gang/games.ex
@@ -147,14 +147,15 @@ defmodule Gang.Games do
     if GameSupervisor.game_exists?(code) do
       case get_game(code) do
         {:ok, state} ->
-          player = Enum.find(state.players, &(&1.id == player_id))
-          chip = Enum.find(player.rank_chips, &(&1.color == state.current_round_color))
-          result = Game.return_chip(code, player_id, chip.rank, chip.color)
-          broadcast_update(code)
-          result
-
-        nil ->
-          {:error, :chip_not_found}
+          with %{} = player <- Enum.find(state.players, &(&1.id == player_id)),
+               %{} = chip <-
+                 Enum.find(player.rank_chips, &(&1.color == state.current_round_color)) do
+            result = Game.return_chip(code, player_id, chip.rank, chip.color)
+            broadcast_update(code)
+            result
+          else
+            nil -> {:error, :chip_not_found}
+          end
 
         error ->
           error

--- a/test/gang/games_test.exs
+++ b/test/gang/games_test.exs
@@ -1,0 +1,15 @@
+defmodule Gang.GamesTest do
+  use ExUnit.Case, async: true
+
+  alias Gang.Games
+  alias Gang.Game.Player
+
+  test "return_rank_chip/2 returns error when player has no chip" do
+    {:ok, code} = Games.create_game()
+
+    player = Player.new("alice")
+    {:ok, _} = Games.join_game(code, player)
+
+    assert {:error, :chip_not_found} = Games.return_rank_chip(code, player.id)
+  end
+end


### PR DESCRIPTION
## Summary
- guard against players returning nonexistent chips
- add regression test for Games.return_rank_chip/2

## Testing
- `mix format` *(fails: Could not find an SCM for dependency :styler)*
- `mix test` *(fails: Hex metadata download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687e79cda2208322a344987752a329fd