### PR TITLE
Allow closing games from lobby (#12)

### DIFF
--- a/lib/gang/game/game.ex
+++ b/lib/gang/game/game.ex
@@ -20,8 +20,12 @@ defmodule Gang.Game do
 
   # Client API
 
-  def start_link(code) do
+  def start_link(code) when is_binary(code) do
     GenServer.start_link(__MODULE__, code, name: via_tuple(code))
+  end
+
+  def start_link({code, owner_id}) do
+    GenServer.start_link(__MODULE__, {code, owner_id}, name: via_tuple(code))
   end
 
   @doc """
@@ -123,8 +127,12 @@ defmodule Gang.Game do
   # Server callbacks
 
   @impl true
-  def init(code) do
+  def init(code) when is_binary(code) do
     {:ok, State.new(code)}
+  end
+
+  def init({code, owner_id}) do
+    {:ok, State.new(code, owner_id)}
   end
 
   @impl true

--- a/lib/gang/game/state.ex
+++ b/lib/gang/game/state.ex
@@ -42,6 +42,7 @@ defmodule Gang.Game.State do
 
   @type t :: %__MODULE__{
           code: String.t(),
+          owner_id: String.t() | nil,
           players: list(Player.t()),
           status: status(),
           current_round: round(),
@@ -60,6 +61,7 @@ defmodule Gang.Game.State do
 
   defstruct [
     :code,
+    :owner_id,
     players: [],
     status: :waiting,
     current_round: :preflop,
@@ -79,9 +81,10 @@ defmodule Gang.Game.State do
   @doc """
   Creates a new game state with a unique code and empty players.
   """
-  def new(code) do
+  def new(code, owner_id \\ nil) do
     %__MODULE__{
       code: code,
+      owner_id: owner_id,
       last_active: DateTime.utc_now(),
       game_created: DateTime.utc_now()
     }

--- a/lib/gang/game/supervisor.ex
+++ b/lib/gang/game/supervisor.ex
@@ -24,13 +24,16 @@ defmodule Gang.Game.Supervisor do
   @doc """
   Creates a new game with a unique code.
   """
-  def create_game do
+  def create_game(owner_id \\ nil) do
     code = generate_unique_code()
 
-    case DynamicSupervisor.start_child(
-           Gang.GameDynamicSupervisor,
-           {Gang.Game, code}
-         ) do
+    child_spec = if owner_id do
+      {Gang.Game, {code, owner_id}}
+    else
+      {Gang.Game, code}
+    end
+
+    case DynamicSupervisor.start_child(Gang.GameDynamicSupervisor, child_spec) do
       {:ok, _pid} -> {:ok, code}
       {:error, reason} -> {:error, reason}
     end

--- a/lib/gang_web/live/lobby_live.html.heex
+++ b/lib/gang_web/live/lobby_live.html.heex
@@ -114,7 +114,7 @@
                 </td>
               </tr>
             <% else %>
-              <%= for %{status: status, players: players, code: game_id} <- @games do %>
+              <%= for %{status: status, players: players, code: game_id, owner_id: owner_id} <- @games do %>
                 <tr class="hover:bg-ctp-surface0/30 transition-colors duration-300">
                   <td class="px-2 md:px-6 py-4 whitespace-nowrap text-ctp-text font-medium">
                     {game_id}
@@ -156,26 +156,39 @@
                   <td class="px-2 md:px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                     <%= if @player.name != "" do %>
                       <% is_player_in_game = Enum.any?(players, &(&1.id == @player.id)) %>
-                      <.link
-                        :if={is_player_in_game}
-                        navigate={~p"/games/#{game_id}"}
-                        class="w-20 md:w-24 inline-flex justify-center items-center gap-1 px-2 md:px-4 py-2 rounded-lg bg-ctp-blue/10 text-ctp-blue hover:bg-ctp-blue/20 transition-colors duration-300 text-xs md:text-sm"
-                      >
-                        Rejoin <span class="text-base md:text-lg">🔄</span>
-                      </.link>
-                      <.link
-                        :if={status == :waiting && !is_player_in_game}
-                        navigate={~p"/games/#{game_id}"}
-                        class="w-20 md:w-24 inline-flex justify-center items-center gap-1 px-2 md:px-4 py-2 rounded-lg bg-ctp-green/10 text-ctp-green hover:bg-ctp-green/20 transition-colors duration-300 text-xs md:text-sm"
-                      >
-                        Join <span class="text-base md:text-lg">▶</span>
-                      </.link>
-                      <span
-                        :if={status == :playing && !is_player_in_game}
-                        class="text-ctp-overlay0 text-xs"
-                      >
-                        In Progress
-                      </span>
+                      <% is_owner = owner_id == @player.id %>
+                      <div class="flex gap-2 justify-end">
+                        <.link
+                          :if={is_player_in_game}
+                          navigate={~p"/games/#{game_id}"}
+                          class="w-20 md:w-24 inline-flex justify-center items-center gap-1 px-2 md:px-4 py-2 rounded-lg bg-ctp-blue/10 text-ctp-blue hover:bg-ctp-blue/20 transition-colors duration-300 text-xs md:text-sm"
+                        >
+                          Rejoin <span class="text-base md:text-lg">🔄</span>
+                        </.link>
+                        <.link
+                          :if={status == :waiting && !is_player_in_game}
+                          navigate={~p"/games/#{game_id}"}
+                          class="w-20 md:w-24 inline-flex justify-center items-center gap-1 px-2 md:px-4 py-2 rounded-lg bg-ctp-green/10 text-ctp-green hover:bg-ctp-green/20 transition-colors duration-300 text-xs md:text-sm"
+                        >
+                          Join <span class="text-base md:text-lg">▶</span>
+                        </.link>
+                        <span
+                          :if={status == :playing && !is_player_in_game}
+                          class="text-ctp-overlay0 text-xs"
+                        >
+                          In Progress
+                        </span>
+                        <button
+                          :if={is_owner}
+                          phx-click="close_game"
+                          phx-value-game_code={game_id}
+                          data-confirm="Are you sure you want to close this game? This action cannot be undone."
+                          class="w-16 md:w-20 inline-flex justify-center items-center gap-1 px-2 md:px-3 py-2 rounded-lg bg-ctp-red/10 text-ctp-red hover:bg-ctp-red/20 transition-colors duration-300 text-xs md:text-sm"
+                          title="Close Game (Owner Only)"
+                        >
+                          Close <span class="text-base md:text-lg">✕</span>
+                        </button>
+                      </div>
                     <% else %>
                       <span class="text-ctp-overlay0 text-xs">Enter Name</span>
                     <% end %>

--- a/test/gang/game/state_test.exs
+++ b/test/gang/game/state_test.exs
@@ -11,6 +11,7 @@ defmodule Gang.Game.StateTest do
       state = State.new("TEST")
 
       assert state.code == "TEST"
+      assert state.owner_id == nil
       assert state.players == []
       assert state.status == :waiting
       assert state.current_round == :preflop
@@ -18,6 +19,27 @@ defmodule Gang.Game.StateTest do
       assert state.alarms == 0
       assert state.community_cards == [nil, nil, nil, nil, nil]
       assert state.all_rank_chips_claimed? == false
+    end
+  end
+
+  describe "new/2" do
+    test "creates a new state with a game code and owner_id" do
+      owner_id = "test-owner-123"
+      state = State.new("TEST", owner_id)
+
+      assert state.code == "TEST"
+      assert state.owner_id == owner_id
+      assert state.players == []
+      assert state.status == :waiting
+    end
+
+    test "creates a new state with nil owner_id when explicitly passed" do
+      state = State.new("TEST", nil)
+
+      assert state.code == "TEST"
+      assert state.owner_id == nil
+      assert state.players == []
+      assert state.status == :waiting
     end
   end
 

--- a/test/gang/games_test.exs
+++ b/test/gang/games_test.exs
@@ -12,4 +12,66 @@ defmodule Gang.GamesTest do
 
     assert {:error, :chip_not_found} = Games.return_rank_chip(code, player.id)
   end
+
+  describe "close_game/2" do
+    test "allows owner to close a game" do
+      owner = Player.new("owner", "owner-id")
+      {:ok, code} = Games.create_game(owner.id)
+
+      # Verify game exists
+      assert {:ok, _state} = Games.get_game(code)
+
+      # Owner should be able to close the game
+      assert :ok = Games.close_game(code, owner.id)
+
+      # Allow process termination to complete
+      Process.sleep(5)
+
+      # Game should no longer exist
+      assert false == Games.game_exists?(code)
+    end
+
+    test "prevents non-owner from closing a game" do
+      owner = Player.new("owner", "owner-id")
+      other_player = Player.new("other", "other-id")
+      {:ok, code} = Games.create_game(owner.id)
+
+      # Other player should not be able to close the game
+      assert {:error, :not_owner} = Games.close_game(code, other_player.id)
+
+      # Game should still exist
+      assert {:ok, _state} = Games.get_game(code)
+    end
+
+    test "returns error when trying to close non-existent game" do
+      player = Player.new("player", "player-id")
+      
+      assert {:error, :game_not_found} = Games.close_game("FAKE", player.id)
+    end
+
+    test "handles case where owner_id is nil" do
+      {:ok, code} = Games.create_game(nil)
+      player = Player.new("player", "player-id")
+
+      # Should not be able to close game with nil owner
+      assert {:error, :not_owner} = Games.close_game(code, player.id)
+    end
+  end
+
+  describe "create_game/1" do
+    test "creates game without owner when no owner_id provided" do
+      {:ok, code} = Games.create_game()
+      {:ok, state} = Games.get_game(code)
+      
+      assert state.owner_id == nil
+    end
+
+    test "creates game with owner when owner_id provided" do
+      owner_id = "test-owner-id"
+      {:ok, code} = Games.create_game(owner_id)
+      {:ok, state} = Games.get_game(code)
+      
+      assert state.owner_id == owner_id
+    end
+  end
 end

--- a/test/gang_web/live/lobby_live_test.exs
+++ b/test/gang_web/live/lobby_live_test.exs
@@ -2,6 +2,8 @@ defmodule GangWeb.LobbyLiveTest do
   use GangWeb.ConnCase
 
   import Phoenix.LiveViewTest
+  alias Gang.Game.Player
+  alias Gang.Games
 
   test "shows lobby with title", %{conn: conn} do
     {:ok, _view, html} = live(conn, ~p"/")
@@ -18,5 +20,87 @@ defmodule GangWeb.LobbyLiveTest do
       |> render_submit()
 
     assert html =~ "Your Player Name: Luke Skywalker"
+  end
+
+  describe "close game functionality" do
+    test "shows close button only for game owner", %{conn: conn} do
+      owner = Player.new("Owner", "owner-id")
+      other_player = Player.new("Other", "other-id")
+      
+      # Create a game with owner
+      {:ok, code} = Games.create_game(owner.id)
+
+      # Connect as owner
+      {:ok, _owner_view, owner_html} = live(conn, ~p"/?player_name=#{owner.name}&player_id=#{owner.id}")
+      
+      # Owner should see close button
+      assert owner_html =~ "Close"
+      assert owner_html =~ "phx-click=\"close_game\""
+      assert owner_html =~ "phx-value-game_code=\"#{code}\""
+
+      # Connect as different player
+      {:ok, _other_view, other_html} = live(conn, ~p"/?player_name=#{other_player.name}&player_id=#{other_player.id}")
+      
+      # Other player should not see close button for games they don't own
+      refute other_html =~ "phx-value-game_code=\"#{code}\""
+    end
+
+    test "owner can successfully close their game", %{conn: conn} do
+      owner = Player.new("Owner", "owner-id")
+      {:ok, code} = Games.create_game(owner.id)
+
+      {:ok, view, _html} = live(conn, ~p"/?player_name=#{owner.name}&player_id=#{owner.id}")
+
+      # Close the game
+      html = render_click(view, "close_game", %{"game_code" => code})
+
+      # Should show success message
+      assert html =~ "Game #{code} has been closed"
+      
+      # Allow process termination to complete
+      Process.sleep(5)
+      
+      # Game should no longer exist
+      assert false == Games.game_exists?(code)
+    end
+
+    test "non-owner cannot close game", %{conn: conn} do
+      owner = Player.new("Owner", "owner-id")
+      other_player = Player.new("Other", "other-id")
+      {:ok, code} = Games.create_game(owner.id)
+
+      {:ok, view, _html} = live(conn, ~p"/?player_name=#{other_player.name}&player_id=#{other_player.id}")
+
+      # Try to close the game as non-owner
+      html = render_click(view, "close_game", %{"game_code" => code})
+
+      # Should show error message
+      assert html =~ "Only the game owner can close this game"
+      
+      # Game should still exist
+      assert {:ok, _state} = Games.get_game(code)
+    end
+
+    test "handles closing non-existent game gracefully", %{conn: conn} do
+      player = Player.new("Player", "player-id")
+      
+      {:ok, view, _html} = live(conn, ~p"/?player_name=#{player.name}&player_id=#{player.id}")
+
+      # Try to close non-existent game
+      html = render_click(view, "close_game", %{"game_code" => "FAKE"})
+
+      # Should show error message
+      assert html =~ "Game not found"
+    end
+
+    test "close button is not shown for games without owner", %{conn: conn} do
+      player = Player.new("Player", "player-id")
+      {:ok, code} = Games.create_game(nil)  # No owner
+
+      {:ok, _view, html} = live(conn, ~p"/?player_name=#{player.name}&player_id=#{player.id}")
+
+      # Should not show close button since no one owns the game
+      refute html =~ "phx-value-game_code=\"#{code}\""
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Add game owner functionality to close games from the lobby
- Only the player who created a game can close it
- Added close button with confirmation dialog in the lobby UI

## Changes Made
- Added `owner_id` field to Game State to track game creators
- Updated game creation flow to set owner when player creates game  
- Implemented `close_game/2` function with owner validation
- Added close button in lobby template for game owners only
- Added comprehensive test coverage for all scenarios

## Test Plan
- [x] Owner can successfully close their game
- [x] Non-owners cannot close games they didn't create
- [x] Close button only appears for game owners
- [x] Proper error handling for edge cases
- [x] Games with nil owners cannot be closed by anyone
- [x] All existing tests continue to pass

## Screenshots
The close button appears as a red "Close ✕" button next to games owned by the current player, with a confirmation dialog to prevent accidental closure.

Resolves #12

🤖 Generated with [Claude Code](https://claude.ai/code)