### PR TITLE
Improve avatar system and player name editing UX

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -29,7 +29,10 @@ const Hooks = {
       const savedName = localStorage.getItem("player_name");
       const savedId = localStorage.getItem("player_id");
       if (savedName && savedId) {
-        this.el.value = savedName;
+        const input = this.el.querySelector('input[name="player_name"]');
+        if (input) {
+          input.value = savedName;
+        }
         // Push the saved name and ID to the server
         this.pushEvent("restore_player_info", {
           player_name: savedName,

--- a/lib/gang/game/game.ex
+++ b/lib/gang/game/game.ex
@@ -51,6 +51,13 @@ defmodule Gang.Game do
     GenServer.call(via_tuple(code), {:update_connection, player_id, connected})
   end
 
+  @doc """
+  Updates a player's information (name and avatar) when they rejoin.
+  """
+  def update_player_info(code, player) when is_binary(code) do
+    GenServer.call(via_tuple(code), {:update_player_info, player})
+  end
+
   def join(game_pid, %Player{} = player) do
     GenServer.call(game_pid, {:join, player})
   end
@@ -178,6 +185,13 @@ defmodule Gang.Game do
   @impl true
   def handle_call({:update_connection, player_id, connected}, _from, state) do
     updated_state = State.update_player_connection(state, player_id, connected)
+    broadcast_update(updated_state)
+    {:reply, {:ok, updated_state}, updated_state}
+  end
+
+  @impl true
+  def handle_call({:update_player_info, player}, _from, state) do
+    updated_state = State.update_player_info(state, player)
     broadcast_update(updated_state)
     {:reply, {:ok, updated_state}, updated_state}
   end

--- a/lib/gang/game/player.ex
+++ b/lib/gang/game/player.ex
@@ -34,7 +34,7 @@ defmodule Gang.Game.Player do
     %__MODULE__{
       id: id,
       name: name,
-      avatar: Avatar.generate(id),
+      avatar: Avatar.generate(name),
       last_activity: DateTime.utc_now()
     }
   end
@@ -58,6 +58,13 @@ defmodule Gang.Game.Player do
   """
   def touch(player) do
     %{player | last_activity: DateTime.utc_now()}
+  end
+
+  @doc """
+  Updates the player's name and regenerates their avatar.
+  """
+  def update_name(player, new_name) do
+    %{player | name: new_name, avatar: Avatar.generate(new_name)}
   end
 
   @doc """

--- a/lib/gang/game/state.ex
+++ b/lib/gang/game/state.ex
@@ -412,6 +412,22 @@ defmodule Gang.Game.State do
   end
 
   @doc """
+  Updates a player's information (name and avatar) when they rejoin.
+  """
+  def update_player_info(state, new_player) do
+    updated_players =
+      Enum.map(state.players, fn player ->
+        if player.id == new_player.id do
+          %{player | name: new_player.name, avatar: new_player.avatar}
+        else
+          player
+        end
+      end)
+
+    %{state | players: updated_players, last_active: DateTime.utc_now()}
+  end
+
+  @doc """
   Deals cards to all players from the given deck.
   Returns a tuple of {updated_players, remaining_deck}.
   """

--- a/lib/gang/games.ex
+++ b/lib/gang/games.ex
@@ -50,9 +50,10 @@ defmodule Gang.Games do
         existing_player = Enum.find(state.players, &(&1.id == player.id))
 
         if existing_player do
-          # Update connection status
+          # Update player info (name/avatar) and connection status
+          Game.update_player_info(code, player)
           Game.update_connection(code, existing_player.id, true)
-          {:ok, existing_player}
+          {:ok, player}
         else
           Game.add_player(code, player)
           broadcast_update(code)

--- a/lib/gang_web/live/game_live.ex
+++ b/lib/gang_web/live/game_live.ex
@@ -336,12 +336,12 @@ defmodule GangWeb.GameLive do
       <%= if length(@game.players) > 0 do %>
         <div class="mt-4">
           <h3 class="text-sm font-medium text-ctp-subtext0 mb-2">Current Players:</h3>
-          <div class="flex flex-wrap justify-center gap-2">
+          <div class="flex flex-wrap justify-center gap-4">
             <%= for player <- @game.players do %>
-              <span class="px-2 py-1 bg-ctp-surface0 text-ctp-text rounded text-sm flex items-center gap-1">
-                <img src={player.avatar} alt="avatar" class="w-4 h-4 rounded" />
-                {player.name}
-              </span>
+              <div class="bg-ctp-surface0 text-ctp-text rounded-lg p-4 flex flex-col items-center gap-3">
+                <img src={player.avatar} alt="avatar" class="w-16 h-16 rounded-xl" />
+                <span class="text-sm font-medium">{player.name}</span>
+              </div>
             <% end %>
           </div>
         </div>
@@ -582,9 +582,12 @@ defmodule GangWeb.GameLive do
       @is_current && "ring-2 ring-ctp-lavender"
     ]}>
       <div class="flex justify-between items-center mb-1">
-        <h3 class="text-sm font-medium text-ctp-text truncate flex-1">
-          {@player.name}
-        </h3>
+        <div class="flex items-center gap-2 flex-1 min-w-0">
+          <img src={@player.avatar} alt="avatar" class="w-10 h-10 rounded-lg flex-shrink-0" />
+          <h3 class="text-sm font-medium text-ctp-text truncate">
+            {@player.name}
+          </h3>
+        </div>
         <span class={[
           "px-1 py-1 text-xs rounded-full ml-1",
           (@player.connected && "bg-ctp-green animate-pulse") ||

--- a/lib/gang_web/live/lobby_live.ex
+++ b/lib/gang_web/live/lobby_live.ex
@@ -27,7 +27,8 @@ defmodule GangWeb.LobbyLive do
         player_id: player_id,
         show_error: false,
         error_message: "",
-        player: player
+        player: player,
+        editing_name: false
       )
       |> UserInfo.store_in_socket(player_name, player_id)
 
@@ -65,6 +66,23 @@ defmodule GangWeb.LobbyLive do
   end
 
   @impl true
+  def handle_event("edit_name", _params, socket) do
+    {:noreply, assign(socket, editing_name: true)}
+  end
+
+  @impl true
+  def handle_event("cancel_edit", _params, socket) do
+    {:noreply, assign(socket, editing_name: false)}
+  end
+
+  @impl true
+  def handle_event("update_preview", %{"player_name" => player_name}, socket) do
+    # Update the preview name but don't save it yet
+    updated_player = %{socket.assigns.player | name: player_name}
+    {:noreply, assign(socket, player: updated_player)}
+  end
+
+  @impl true
   def handle_event("set_player_name", %{"player_name" => player_name}, socket) do
     final_player_id =
       case socket.assigns.player.id do
@@ -73,7 +91,12 @@ defmodule GangWeb.LobbyLive do
         id -> id
       end
 
-    {:noreply, UserInfo.update_user_info(socket, player_name, final_player_id)}
+    socket =
+      socket
+      |> UserInfo.update_user_info(player_name, final_player_id)
+      |> assign(editing_name: false)
+
+    {:noreply, socket}
   end
 
   def handle_event("restore_player_info", %{"player_name" => player_name, "player_id" => player_id}, socket) do

--- a/lib/gang_web/live/lobby_live.ex
+++ b/lib/gang_web/live/lobby_live.ex
@@ -77,8 +77,8 @@ defmodule GangWeb.LobbyLive do
 
   @impl true
   def handle_event("update_preview", %{"player_name" => player_name}, socket) do
-    # Update the preview name but don't save it yet
-    updated_player = %{socket.assigns.player | name: player_name}
+    # Update the preview name and regenerate avatar but don't save it yet
+    updated_player = Player.update_name(socket.assigns.player, player_name)
     {:noreply, assign(socket, player: updated_player)}
   end
 

--- a/lib/gang_web/live/lobby_live.html.heex
+++ b/lib/gang_web/live/lobby_live.html.heex
@@ -7,34 +7,71 @@
   </div>
   
 <!-- Player Name Input with Enhanced Styling -->
-  <div class="bg-ctp-mantle/80 backdrop-blur-sm rounded-xl shadow-xl shadow-ctp-crust/20 p-8 mb-4 transform hover:shadow-2xl hover:-translate-y-1 transition-all duration-300">
-    <h2 class="text-xl font-semibold mb-4 text-ctp-text flex items-center gap-2">
-      <span class="text-ctp-mauve">👤</span> Your Player Name: {@player.name}
-    </h2>
-    <.form for={%{}} phx-submit="set_player_name" id="player-name-form">
-      <div class="flex items-center gap-4 justify-center">
-        <div class="flex-grow">
+  <div id="player-name-section" class="bg-ctp-mantle/80 backdrop-blur-sm rounded-xl shadow-xl shadow-ctp-crust/20 p-6 mb-4 transform hover:shadow-2xl hover:-translate-y-1 transition-all duration-300" phx-hook="SetPlayerName">
+    <%= if @player.name != "" and not @editing_name do %>
+      <!-- Display Mode: Avatar + Name + Edit Button -->
+      <div class="flex items-center justify-center gap-4">
+        <img
+          src={Gang.Avatar.generate(@player.name)}
+          alt="Your avatar"
+          class="w-16 h-16 rounded-xl shadow-lg"
+        />
+        <span class="text-xl font-semibold text-ctp-text">{@player.name}</span>
+        <button
+          phx-click="edit_name"
+          class="ml-2 p-2 rounded-lg bg-ctp-surface0/50 hover:bg-ctp-surface0 text-ctp-subtext0 hover:text-ctp-text transition-all duration-200"
+          title="Edit name"
+        >
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+            <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z">
+            </path>
+          </svg>
+        </button>
+      </div>
+    <% else %>
+      <!-- Edit Mode: Compact Input Form -->
+      <div class="flex items-center justify-center gap-4">
+        <%= if @player.name != "" do %>
+          <img
+            src={Gang.Avatar.generate(@player.name)}
+            alt="Your avatar"
+            class="w-12 h-12 rounded-lg shadow-lg"
+          />
+        <% end %>
+        <.form
+          for={%{}}
+          phx-submit="set_player_name"
+          phx-change="update_preview"
+          id="player-name-form"
+          class="flex items-center gap-2"
+        >
           <.input
             type="text"
             name="player_name"
             placeholder="Enter Your Name"
             value={@player.name}
             id="player-name-input"
-            phx-hook="SetPlayerName"
             required
-            class="bg-ctp-base/50 border-ctp-surface0 focus:border-ctp-mauve transition-colors duration-300"
+            class="bg-ctp-base/50 border-ctp-surface0 focus:border-ctp-mauve transition-colors duration-300 w-48"
           />
-        </div>
-        <div>
           <.button
             type="submit"
-            class="bg-ctp-mauve hover:bg-ctp-pink transition-colors duration-300 transform hover:scale-105"
+            class="bg-ctp-mauve hover:bg-ctp-pink transition-colors duration-300 px-3 py-2 text-sm"
           >
             Save
           </.button>
-        </div>
+          <%= if @player.name != "" do %>
+            <button
+              type="button"
+              phx-click="cancel_edit"
+              class="bg-ctp-surface0 hover:bg-ctp-surface1 text-ctp-subtext0 hover:text-ctp-text transition-colors duration-300 px-3 py-2 text-sm rounded-md"
+            >
+              Cancel
+            </button>
+          <% end %>
+        </.form>
       </div>
-    </.form>
+    <% end %>
   </div>
 
   <div :if={@player.name != ""} class="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/test/gang/game/player_test.exs
+++ b/test/gang/game/player_test.exs
@@ -1,0 +1,87 @@
+defmodule Gang.Game.PlayerTest do
+  use ExUnit.Case, async: true
+
+  alias Gang.Game.Player
+
+  describe "new/2" do
+    test "creates a player with name and generates avatar from name" do
+      player = Player.new("Alice", "test-id")
+
+      assert player.name == "Alice"
+      assert player.id == "test-id"
+      assert player.avatar == "https://api.dicebear.com/9.x/fun-emoji/svg?seed=Alice&radius=30&backgroundColor=f5bde6,c6a0f6,ed8796,ee99a0,f5a97f,eed49f,a6da95,8bd5ca,91d7e3,7dc4e4,8aadf4,b7bdf8"
+      assert player.connected == true
+      assert player.cards == []
+      assert player.rank_chips == []
+      assert %DateTime{} = player.last_activity
+    end
+
+    test "generates UUID when no ID provided" do
+      player = Player.new("Bob")
+
+      assert player.name == "Bob"
+      assert is_binary(player.id)
+      assert String.length(player.id) == 36  # UUID length
+      assert player.avatar == "https://api.dicebear.com/9.x/fun-emoji/svg?seed=Bob&radius=30&backgroundColor=f5bde6,c6a0f6,ed8796,ee99a0,f5a97f,eed49f,a6da95,8bd5ca,91d7e3,7dc4e4,8aadf4,b7bdf8"
+    end
+  end
+
+  describe "update_name/2" do
+    test "updates player name and regenerates avatar" do
+      player = Player.new("Alice", "test-id")
+      updated_player = Player.update_name(player, "Bob")
+
+      assert updated_player.name == "Bob"
+      assert updated_player.id == "test-id"  # ID stays the same
+      assert updated_player.avatar == "https://api.dicebear.com/9.x/fun-emoji/svg?seed=Bob&radius=30&backgroundColor=f5bde6,c6a0f6,ed8796,ee99a0,f5a97f,eed49f,a6da95,8bd5ca,91d7e3,7dc4e4,8aadf4,b7bdf8"
+      
+      # Other properties remain unchanged
+      assert updated_player.connected == player.connected
+      assert updated_player.cards == player.cards
+      assert updated_player.rank_chips == player.rank_chips
+      assert updated_player.last_activity == player.last_activity
+    end
+
+    test "different names generate different avatars" do
+      player = Player.new("Alice", "test-id")
+      alice_avatar = player.avatar
+
+      updated_player = Player.update_name(player, "Charlie")
+      charlie_avatar = updated_player.avatar
+
+      assert alice_avatar != charlie_avatar
+      assert String.contains?(alice_avatar, "seed=Alice")
+      assert String.contains?(charlie_avatar, "seed=Charlie")
+    end
+  end
+
+  describe "connect/1" do
+    test "marks player as connected and updates activity" do
+      player = Player.new("Alice") |> Player.disconnect()
+      connected_player = Player.connect(player)
+
+      assert connected_player.connected == true
+      assert DateTime.compare(connected_player.last_activity, player.last_activity) == :gt
+    end
+  end
+
+  describe "disconnect/1" do
+    test "marks player as disconnected" do
+      player = Player.new("Alice")
+      disconnected_player = Player.disconnect(player)
+
+      assert disconnected_player.connected == false
+      assert disconnected_player.last_activity == player.last_activity
+    end
+  end
+
+  describe "touch/1" do
+    test "updates last activity timestamp" do
+      player = Player.new("Alice")
+      Process.sleep(1)  # Ensure time difference
+      touched_player = Player.touch(player)
+
+      assert DateTime.compare(touched_player.last_activity, player.last_activity) == :gt
+    end
+  end
+end

--- a/test/gang/games_test.exs
+++ b/test/gang/games_test.exs
@@ -13,6 +13,110 @@ defmodule Gang.GamesTest do
     assert {:error, :chip_not_found} = Games.return_rank_chip(code, player.id)
   end
 
+  describe "join_game/2" do
+    test "adds new player to game" do
+      {:ok, code} = Games.create_game()
+      player = Player.new("Alice", "test-id")
+
+      {:ok, _} = Games.join_game(code, player)
+      {:ok, state} = Games.get_game(code)
+
+      assert length(state.players) == 1
+      game_player = hd(state.players)
+      assert game_player.name == "Alice"
+      assert game_player.id == "test-id"
+    end
+
+    test "updates existing player info when rejoining with same ID" do
+      {:ok, code} = Games.create_game()
+      original_player = Player.new("Alice", "test-id")
+
+      # Join game initially
+      {:ok, _} = Games.join_game(code, original_player)
+      {:ok, initial_state} = Games.get_game(code)
+      initial_player = hd(initial_state.players)
+      assert initial_player.name == "Alice"
+      assert String.contains?(initial_player.avatar, "seed=Alice")
+
+      # Rejoin with updated name (simulating name change in lobby)
+      updated_player = Player.new("Bob", "test-id")  # Same ID, different name
+      {:ok, _} = Games.join_game(code, updated_player)
+      {:ok, updated_state} = Games.get_game(code)
+
+      # Should still have only one player but with updated info
+      assert length(updated_state.players) == 1
+      game_player = hd(updated_state.players)
+      assert game_player.name == "Bob"
+      assert game_player.id == "test-id"
+      assert String.contains?(game_player.avatar, "seed=Bob")
+      refute String.contains?(game_player.avatar, "seed=Alice")
+    end
+
+    test "marks existing player as connected when rejoining" do
+      {:ok, code} = Games.create_game()
+      player = Player.new("Alice", "test-id")
+
+      # Join initially
+      {:ok, _} = Games.join_game(code, player)
+      
+      # Simulate disconnection
+      Games.update_connection(code, player.id, false)
+      {:ok, state} = Games.get_game(code)
+      game_player = hd(state.players)
+      assert game_player.connected == false
+
+      # Rejoin should mark as connected
+      {:ok, _} = Games.join_game(code, player)
+      {:ok, updated_state} = Games.get_game(code)
+      updated_player = hd(updated_state.players)
+      assert updated_player.connected == true
+    end
+
+    test "returns updated player data when rejoining" do
+      {:ok, code} = Games.create_game()
+      original_player = Player.new("Alice", "test-id")
+
+      # Join initially
+      {:ok, _} = Games.join_game(code, original_player)
+
+      # Rejoin with updated info
+      updated_player = Player.new("Charlie", "test-id")
+      {:ok, returned_player} = Games.join_game(code, updated_player)
+
+      # Should return the updated player data, not the original
+      assert returned_player.name == "Charlie"
+      assert returned_player.id == "test-id"
+      assert String.contains?(returned_player.avatar, "seed=Charlie")
+    end
+
+    test "handles multiple players with info updates" do
+      {:ok, code} = Games.create_game()
+      player1 = Player.new("Alice", "id-1")
+      player2 = Player.new("Bob", "id-2")
+
+      # Both join initially
+      {:ok, _} = Games.join_game(code, player1)
+      {:ok, _} = Games.join_game(code, player2)
+      {:ok, state} = Games.get_game(code)
+      assert length(state.players) == 2
+
+      # Player1 rejoins with updated info
+      updated_player1 = Player.new("UpdatedAlice", "id-1")
+      {:ok, _} = Games.join_game(code, updated_player1)
+      {:ok, updated_state} = Games.get_game(code)
+
+      # Should still have 2 players
+      assert length(updated_state.players) == 2
+      
+      # Player1 should be updated, Player2 unchanged
+      updated_p1 = Enum.find(updated_state.players, &(&1.id == "id-1"))
+      unchanged_p2 = Enum.find(updated_state.players, &(&1.id == "id-2"))
+      
+      assert updated_p1.name == "UpdatedAlice"
+      assert unchanged_p2.name == "Bob"
+    end
+  end
+
   describe "close_game/2" do
     test "allows owner to close a game" do
       owner = Player.new("owner", "owner-id")

--- a/test/gang_web/live/lobby_live_test.exs
+++ b/test/gang_web/live/lobby_live_test.exs
@@ -20,7 +20,7 @@ defmodule GangWeb.LobbyLiveTest do
       |> form("#player-name-form", %{player_name: "Luke Skywalker"})
       |> render_submit()
 
-    assert html =~ "Your Player Name: Luke Skywalker"
+    assert html =~ "Luke Skywalker"
   end
 
   describe "close game functionality" do


### PR DESCRIPTION
## Summary
Enhances the avatar system with better UX for editing player names and ensures avatars stay consistent when rejoining games.

## Changes
- **Better avatars**: Switched to DiceBear API with Catppuccin colors
- **Improved edit UX**: Clean display mode with edit button instead of always-visible input
- **Fixed avatar consistency**: Same name generates same avatar across lobby and games
- **Player info sync**: Name/avatar changes persist when rejoining games
- **localStorage fixes**: Resolved persistence issues with conditional rendering

## Test plan
- [x] Avatar consistency across all views
- [x] Edit mode functionality works correctly
- [x] Player info updates when rejoining games
- [x] localStorage persistence works after page refresh
- [x] All existing tests pass + added comprehensive test coverage

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>