### PR TITLE
Fix lobby name input disappearing after first character

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,3 +83,9 @@ mix credo                        # Run static analysis (if installed)
 
 ### Current Branch Notes
 The `shareable-links` branch has uncommitted changes to styling files. Be aware of these when making UI changes.
+
+## Local Development Notes
+- This app runs on localhost:4090
+
+## AI Interaction Notes
+- I will run the mix phx.server command. You dont need to ever start the server

--- a/lib/gang_web/live/lobby_live.ex
+++ b/lib/gang_web/live/lobby_live.ex
@@ -28,7 +28,9 @@ defmodule GangWeb.LobbyLive do
         show_error: false,
         error_message: "",
         player: player,
-        editing_name: false
+        editing_name: false,
+        temp_name: "",
+        name_form: to_form(%{"player_name" => player_name || ""})
       )
       |> UserInfo.store_in_socket(player_name, player_id)
 
@@ -67,23 +69,27 @@ defmodule GangWeb.LobbyLive do
 
   @impl true
   def handle_event("edit_name", _params, socket) do
-    {:noreply, assign(socket, editing_name: true)}
+    form_data = %{"player_name" => socket.assigns.player.name}
+    {:noreply, assign(socket, editing_name: true, temp_name: socket.assigns.player.name, name_form: to_form(form_data))}
   end
 
   @impl true
   def handle_event("cancel_edit", _params, socket) do
-    {:noreply, assign(socket, editing_name: false)}
+    form_data = %{"player_name" => socket.assigns.player.name}
+    {:noreply, assign(socket, editing_name: false, temp_name: "", name_form: to_form(form_data))}
   end
 
   @impl true
-  def handle_event("update_preview", %{"player_name" => player_name}, socket) do
-    # Update the preview name and regenerate avatar but don't save it yet
-    updated_player = Player.update_name(socket.assigns.player, player_name)
-    {:noreply, assign(socket, player: updated_player)}
+  def handle_event("update_preview", params, socket) do
+    # Only update temp_name for preview, don't change the actual player name yet
+    player_name = get_in(params, ["player_name"]) || ""
+    form_data = %{"player_name" => player_name}
+    {:noreply, assign(socket, temp_name: player_name, name_form: to_form(form_data))}
   end
 
   @impl true
-  def handle_event("set_player_name", %{"player_name" => player_name}, socket) do
+  def handle_event("set_player_name", params, socket) do
+    player_name = get_in(params, ["player_name"]) || ""
     final_player_id =
       case socket.assigns.player.id do
         nil -> Ecto.UUID.generate()
@@ -91,10 +97,11 @@ defmodule GangWeb.LobbyLive do
         id -> id
       end
 
+    form_data = %{"player_name" => player_name}
     socket =
       socket
       |> UserInfo.update_user_info(player_name, final_player_id)
-      |> assign(editing_name: false)
+      |> assign(editing_name: false, temp_name: "", name_form: to_form(form_data))
 
     {:noreply, socket}
   end

--- a/lib/gang_web/live/lobby_live.html.heex
+++ b/lib/gang_web/live/lobby_live.html.heex
@@ -35,25 +35,24 @@
     <% else %>
       <!-- Edit Mode: Compact Input Form -->
       <div class="flex items-center justify-center gap-4">
-        <%= if @player.name != "" do %>
+        <%= if @player.name != "" or @temp_name != "" do %>
           <img
-            src={Gang.Avatar.generate(@player.name)}
+            src={Gang.Avatar.generate(if @temp_name != "", do: @temp_name, else: @player.name)}
             alt="Your avatar"
             class="w-12 h-12 rounded-lg shadow-lg"
           />
         <% end %>
         <.form
-          for={%{}}
+          for={@name_form}
           phx-submit="set_player_name"
           phx-change="update_preview"
           id="player-name-form"
           class="flex items-center gap-2"
         >
           <.input
+            field={@name_form[:player_name]}
             type="text"
-            name="player_name"
             placeholder="Enter Your Name"
-            value={@player.name}
             id="player-name-input"
             required
             class="bg-ctp-base/50 border-ctp-surface0 focus:border-ctp-mauve transition-colors duration-300 w-48"


### PR DESCRIPTION
## Summary
- Fixes issue #23 where the name input form would disappear after typing the first character
- Added `temp_name` field to track user input during preview without affecting display logic
- Implemented proper form handling using Phoenix's `to_form` helper for better accessibility
- Input now shows preview avatar while typing and only saves when "Save" button is clicked

## Test plan
- [x] Navigate to lobby without existing user info
- [x] Verify name input form is displayed
- [x] Type characters in the name input - form should remain visible
- [x] Verify preview avatar updates as you type
- [x] Click "Save" button to confirm name is saved and lobby interface appears
- [x] Test editing existing name works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)